### PR TITLE
Codenames: Handle one team's card selection causing other team to win

### DIFF
--- a/src/games/codenames/index.ts
+++ b/src/games/codenames/index.ts
@@ -192,22 +192,32 @@ export default class Codenames implements Game {
                 this.start();
                 break;
             case "card":
+                // Card already hit, no-op
                 if (this.boardRevealed[action.rowIndex][action.colIndex]) return;
 
                 this.boardRevealed[action.rowIndex][action.colIndex] = true;
-                if (this.boardColors[action.rowIndex][action.colIndex] === "white" || this.boardColors[action.rowIndex][action.colIndex] === (this.getPlayerTeam(playerName) === "red" ? "blue" : "red")) {
-                    this.currentTurn = this.currentTurn === "red" ? "blue" : "red";
+                if (this.boardColors[action.rowIndex][action.colIndex] === "white") {
+                    // Hit a bystander, end of turn
+                    this.currentTurn = this.otherTeam(this.currentTurn);
+                } else if (this.boardColors[action.rowIndex][action.colIndex] === this.otherTeam(this.getPlayerTeam(playerName))) {
+                    // Hit a card of the other team, end of turn, and check whether it made other team win
+                    this.currentTurn = this.otherTeam(this.currentTurn);
+                    if (this.isWon(this.currentTurn)) {
+                        this.status = "game-over";
+                    }
                 } else if (this.boardColors[action.rowIndex][action.colIndex] === "black") {
-                    this.currentTurn = this.currentTurn === "red" ? "blue" : "red";
+                    // Hit the assassin, end of turn, and other team won
+                    this.currentTurn = this.otherTeam(this.currentTurn);
                     this.status = "game-over";
                 } else {
-                    if (this.isWon(this.getPlayerTeam(playerName))) {
+                    // Hit a card of the current team, check whether it made current team win
+                    if (this.isWon(this.currentTurn)) {
                         this.status = "game-over";
                     }
                 }
                 break;
             case "end-turn":
-                this.currentTurn = this.currentTurn === "red" ? "blue" : "red";
+                this.currentTurn = this.otherTeam(this.currentTurn);
                 break;
         }
 


### PR DESCRIPTION
One especially funny way for a game to end is when a player on one team selects the last card of the opposing team, causing them to win. Currently the logic for this doesn't work properly, as we only check whether a team won when that team plays a card of their own.

Fix this by checking whether the other team won if the current team accidentally plays one of their cards.

Also refactor a little bit to use existing helper methods and add some comments for convenience.